### PR TITLE
Standardize dbms_name trait method

### DIFF
--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -102,6 +102,25 @@ pub trait Connection: Send {
         Box::pin(async move { Ok(()) })
     }
 
+    /// Returns the name of the Database Management System (DBMS) this connection
+    /// is talking to.
+    ///
+    /// This is intended to be compatible with the ODBC `SQL_DBMS_NAME` info value
+    /// and should generally return the same string as an ODBC driver for the same
+    /// database. This makes it easier to write conditional SQL or feature probes
+    /// that work across both native and ODBC connections.
+    ///
+    /// Typical return values include:
+    /// - "PostgreSQL"
+    /// - "MySQL"
+    /// - "SQLite"
+    /// - "Microsoft SQL Server" (includes Azure SQL)
+    /// - ODBC: the exact string reported by the driver via `SQL_DBMS_NAME`
+    ///
+    /// Implementations for built-in drivers return a well-known constant string,
+    /// while the ODBC driver queries the underlying driver at runtime.
+    fn dbms_name(&mut self) -> BoxFuture<'_, Result<String, Error>>;
+
     #[doc(hidden)]
     fn flush(&mut self) -> BoxFuture<'_, Result<(), Error>>;
 

--- a/sqlx-core/src/mssql/connection/mod.rs
+++ b/sqlx-core/src/mssql/connection/mod.rs
@@ -81,4 +81,8 @@ impl Connection for MssqlConnection {
     fn should_flush(&self) -> bool {
         !self.stream.wbuf.is_empty()
     }
+
+    fn dbms_name(&mut self) -> BoxFuture<'_, Result<String, Error>> {
+        futures_util::future::ready(Ok("Microsoft SQL Server".to_string())).boxed()
+    }
 }

--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -107,4 +107,8 @@ impl Connection for MySqlConnection {
     {
         Transaction::begin(self)
     }
+
+    fn dbms_name(&mut self) -> BoxFuture<'_, Result<String, Error>> {
+        futures_util::future::ready(Ok("MySQL".to_string())).boxed()
+    }
 }

--- a/sqlx-core/src/odbc/connection/mod.rs
+++ b/sqlx-core/src/odbc/connection/mod.rs
@@ -95,14 +95,7 @@ impl OdbcConnection {
         })
     }
 
-    /// Returns the name of the actual Database Management System (DBMS) this
-    /// connection is talking to as reported by the ODBC driver.
-    pub async fn dbms_name(&mut self) -> Result<String, Error> {
-        self.with_conn("dbms_name", move |conn| {
-            Ok(conn.database_management_system_name()?)
-        })
-        .await
-    }
+    // (dbms_name moved to the Connection trait implementation)
 
     pub(crate) async fn ping_blocking(&mut self) -> Result<(), Error> {
         self.with_conn("ping", move |conn| {
@@ -236,6 +229,15 @@ impl Connection for OdbcConnection {
 
     fn clear_cached_statements(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(self.clear_cached_statements())
+    }
+
+    fn dbms_name(&mut self) -> BoxFuture<'_, Result<String, Error>> {
+        Box::pin(async move {
+            self.with_conn("dbms_name", move |conn| {
+                Ok(conn.database_management_system_name()?)
+            })
+            .await
+        })
     }
 }
 

--- a/sqlx-core/src/postgres/connection/mod.rs
+++ b/sqlx-core/src/postgres/connection/mod.rs
@@ -205,4 +205,8 @@ impl Connection for PgConnection {
     fn should_flush(&self) -> bool {
         !self.stream.wbuf.is_empty()
     }
+
+    fn dbms_name(&mut self) -> BoxFuture<'_, Result<String, Error>> {
+        futures_util::future::ready(Ok("PostgreSQL".to_string())).boxed()
+    }
 }

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -202,6 +202,10 @@ impl Connection for SqliteConnection {
     fn should_flush(&self) -> bool {
         false
     }
+
+    fn dbms_name(&mut self) -> BoxFuture<'_, Result<String, Error>> {
+        Box::pin(async move { Ok("SQLite".to_string()) })
+    }
 }
 
 impl LockedSqliteHandle<'_> {


### PR DESCRIPTION
Move `dbms_name` to the `Connection` trait to standardize DBMS name retrieval across all connection types, ensuring compatibility with ODBC `SQL_DBMS_NAME` conventions.

---
<a href="https://cursor.com/background-agent?bcId=bc-4052314f-37c5-4727-82b2-0d93395ffa29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4052314f-37c5-4727-82b2-0d93395ffa29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

