### PR TITLE
Type_info unimplemented message

### DIFF
--- a/sqlx-core/src/any/type.rs
+++ b/sqlx-core/src/any/type.rs
@@ -9,11 +9,8 @@ macro_rules! impl_any_type {
         impl crate::types::Type<crate::any::Any> for $ty {
             fn type_info() -> crate::any::AnyTypeInfo {
                 panic!(
-                    "Type::type_info() is not implemented for Any \n\
-                     \n\
-                     This is because `Any` is a dynamic driver and does not support compile-time type verification. \n\
-                     \n\
-                     If you are using `query!` or `query_as!`, use `query` or `query_as` instead."
+                    "Type::type_info() is not implemented for Any because it is a dynamic driver and does not support compile-time type verification. (for type `{}`)",
+                    std::any::type_name::<$ty>(),
                 );
             }
 

--- a/sqlx-core/src/any/type.rs
+++ b/sqlx-core/src/any/type.rs
@@ -8,8 +8,13 @@ macro_rules! impl_any_type {
     ($ty:ty) => {
         impl crate::types::Type<crate::any::Any> for $ty {
             fn type_info() -> crate::any::AnyTypeInfo {
-                // FIXME: nicer panic explaining why this isn't possible
-                unimplemented!()
+                panic!(
+                    "Type::type_info() is not implemented for Any \n\
+                     \n\
+                     This is because `Any` is a dynamic driver and does not support compile-time type verification. \n\
+                     \n\
+                     If you are using `query!` or `query_as!`, use `query` or `query_as` instead."
+                );
             }
 
             fn compatible(ty: &crate::any::AnyTypeInfo) -> bool {

--- a/sqlx-core/src/any/type.rs
+++ b/sqlx-core/src/any/type.rs
@@ -9,7 +9,7 @@ macro_rules! impl_any_type {
         impl crate::types::Type<crate::any::Any> for $ty {
             fn type_info() -> crate::any::AnyTypeInfo {
                 panic!(
-                    "Type::type_info() is not implemented for Any because it is a dynamic driver and does not support compile-time type verification. (for type `{}`)",
+                    "Type<Any>::type_info() is not implemented for {}. type_info should not be called on base types.",
                     std::any::type_name::<$ty>(),
                 );
             }


### PR DESCRIPTION
Improve the panic message for `Type<Any>::type_info()` to guide users on correct usage with the `Any` driver.

---
<a href="https://cursor.com/background-agent?bcId=bc-426b7ac5-20ee-4035-9dcb-d093c3263751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-426b7ac5-20ee-4035-9dcb-d093c3263751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

